### PR TITLE
Signup logo and app name changed.

### DIFF
--- a/Pages/Auth/SignupPage.xaml
+++ b/Pages/Auth/SignupPage.xaml
@@ -18,7 +18,7 @@
         <!-- Ground and Go Logo -->
 
         <Image
-            Source="black_and_white.webp"
+            Source="black_and_white2.webp"
             Grid.Row="0"
             HeightRequest="500"
             Aspect="AspectFit"/>

--- a/ground_and_go.csproj
+++ b/ground_and_go.csproj
@@ -12,7 +12,7 @@
         <Nullable>enable</Nullable>
         <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
-        <ApplicationTitle>ground_and_go</ApplicationTitle>
+        <ApplicationTitle>Ground &amp; Go</ApplicationTitle>
 
         <ApplicationId>com.companyname.ground_and_go</ApplicationId>
 


### PR DESCRIPTION
The signup page's logo was changed to be the new logo used on the home and login pages. The name of the app was changed from "ground_and_go" to "Ground & Go".